### PR TITLE
Add filtering to the API

### DIFF
--- a/server/src/main/java/umm3601/todo/TodoController.java
+++ b/server/src/main/java/umm3601/todo/TodoController.java
@@ -112,6 +112,9 @@ public class TodoController {
         if (queryParams.containsKey("owner")) {
             filterDoc = filterDoc.append("owner", queryParams.get("owner")[0]);
         }
+        if (queryParams.containsKey("status")) {
+            filterDoc = filterDoc.append("status", queryParams.get("status")[0].equalsIgnoreCase("complete") || queryParams.get("status")[0].equalsIgnoreCase("true"));
+        }
 
         //FindIterable comes from mongo, Document comes from Gson
         FindIterable<Document> matchingTodos = todoCollection.find(filterDoc);

--- a/server/src/main/java/umm3601/todo/TodoController.java
+++ b/server/src/main/java/umm3601/todo/TodoController.java
@@ -115,6 +115,9 @@ public class TodoController {
         if (queryParams.containsKey("status")) {
             filterDoc = filterDoc.append("status", queryParams.get("status")[0].equalsIgnoreCase("complete") || queryParams.get("status")[0].equalsIgnoreCase("true"));
         }
+        if (queryParams.containsKey("category")) {
+            filterDoc = filterDoc.append("category", queryParams.get("category")[0]);
+        }
 
         //FindIterable comes from mongo, Document comes from Gson
         FindIterable<Document> matchingTodos = todoCollection.find(filterDoc);

--- a/server/src/main/java/umm3601/todo/TodoController.java
+++ b/server/src/main/java/umm3601/todo/TodoController.java
@@ -109,6 +109,9 @@ public class TodoController {
         Document filterDoc = new Document();
 
 
+        if (queryParams.containsKey("owner")) {
+            filterDoc = filterDoc.append("owner", queryParams.get("owner")[0]);
+        }
 
         //FindIterable comes from mongo, Document comes from Gson
         FindIterable<Document> matchingTodos = todoCollection.find(filterDoc);

--- a/server/src/main/java/umm3601/todo/TodoController.java
+++ b/server/src/main/java/umm3601/todo/TodoController.java
@@ -12,6 +12,7 @@ import spark.Response;
 
 import java.util.Iterator;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 import static com.mongodb.client.model.Filters.eq;
 
@@ -117,6 +118,10 @@ public class TodoController {
         }
         if (queryParams.containsKey("category")) {
             filterDoc = filterDoc.append("category", queryParams.get("category")[0]);
+        }
+        if (queryParams.containsKey("contains")) {
+            filterDoc = filterDoc.append("body", Pattern.compile(queryParams.get("contains")[0], Pattern.CASE_INSENSITIVE));
+            System.out.println(filterDoc);
         }
 
         //FindIterable comes from mongo, Document comes from Gson

--- a/server/src/test/java/umm3601/todo/TodoControllerSpec.java
+++ b/server/src/test/java/umm3601/todo/TodoControllerSpec.java
@@ -139,6 +139,21 @@ public class TodoControllerSpec {
         assertEquals("Status should match", true, docs.get(0).asDocument().get("status").asBoolean().getValue());
     }
 
+    @Test
+    public void getTodosWithCategory() {
+        Map<String, String[]> argMap = new HashMap<>();
+        argMap.put("category", new String[] { "homework" });
+        String jsonResult = todoController.getTodos(argMap);
+        BsonArray docs = parseJsonArray(jsonResult);
+
+        assertEquals("Should be 2 todos", 2, docs.size());
+        List<String> categories = docs
+            .stream()
+            .map(TodoControllerSpec::getCategory)
+            .collect(Collectors.toList());
+        List<String> expectedCategories = Arrays.asList("homework", "homework");
+        assertEquals("Categories should match", expectedCategories, categories);
+    }
     public void getTodobyId() {
         String jsonResult = todoController.getTodo(exampleTodoID.toHexString());
         Document exampleTodoDoc = Document.parse(jsonResult);

--- a/server/src/test/java/umm3601/todo/TodoControllerSpec.java
+++ b/server/src/test/java/umm3601/todo/TodoControllerSpec.java
@@ -82,18 +82,13 @@ public class TodoControllerSpec {
         return ((BsonString) doc.get("owner")).getValue();
     }
 
-    private static String getID(BsonValue val) {
-        BsonDocument doc = val.asDocument();
-        return ((BsonString) doc.get("_id")).getValue();
-    }
-
     private static String getCategory(BsonValue val) {
         BsonDocument doc = val.asDocument();
         return ((BsonString) doc.get("category")).getValue();
     }
 
     @Test
-    public void getAllUsers() {
+    public void getAllTodos() {
         Map<String, String[]> emptyMap = new HashMap<>();
         String jsonResult = todoController.getTodos(emptyMap);
         BsonArray docs = parseJsonArray(jsonResult);
@@ -117,6 +112,22 @@ public class TodoControllerSpec {
     }
 
     @Test
+    public void getTodosWithOwner() {
+        Map<String, String[]> argMap = new HashMap<>();
+        argMap.put("owner", new String[]{"Fry"});
+        String jsonResult = todoController.getTodos(argMap);
+        BsonArray docs = parseJsonArray(jsonResult);
+
+        assertEquals("Should be 2 todos", 2, docs.size());
+        List<String> owners = docs
+            .stream()
+            .map(TodoControllerSpec::getOwner)
+            .sorted()
+            .collect(Collectors.toList());
+        List<String> expectedOwners = Arrays.asList("Fry", "Fry");
+        assertEquals("Owners should match", expectedOwners, owners);
+    }
+
     public void getTodobyId() {
         String jsonResult = todoController.getTodo(exampleTodoID.toHexString());
         Document exampleTodoDoc = Document.parse(jsonResult);

--- a/server/src/test/java/umm3601/todo/TodoControllerSpec.java
+++ b/server/src/test/java/umm3601/todo/TodoControllerSpec.java
@@ -140,6 +140,19 @@ public class TodoControllerSpec {
     }
 
     @Test
+    public void getTodosWithBody() {
+        Map<String, String[]> argMap = new HashMap<>();
+        argMap.put("contains", new String[] { "In sunt ex non tempor cillum commodo" });
+        String jsonResult = todoController.getTodos(argMap);
+        BsonArray docs = parseJsonArray(jsonResult);
+
+        assertEquals("Should be 1 todo", 1, docs.size());
+        assertEquals("Body should match", "In sunt ex non tempor cillum commodo amet incididunt anim qui commodo quis. Cillum non labore ex sint esse.",
+            docs.get(0).asDocument().get("body").asString().getValue());
+        assertEquals("Owner should match", "Blanche", docs.get(0).asDocument().get("owner").asString().getValue());
+    }
+
+    @Test
     public void getTodosWithCategory() {
         Map<String, String[]> argMap = new HashMap<>();
         argMap.put("category", new String[] { "homework" });

--- a/server/src/test/java/umm3601/todo/TodoControllerSpec.java
+++ b/server/src/test/java/umm3601/todo/TodoControllerSpec.java
@@ -167,6 +167,19 @@ public class TodoControllerSpec {
         List<String> expectedCategories = Arrays.asList("homework", "homework");
         assertEquals("Categories should match", expectedCategories, categories);
     }
+
+    @Test
+    public void getTodosWithCategoryandOwner() {
+        Map<String, String[]> argMap = new HashMap<>();
+        argMap.put("category", new String[] { "homework" });
+        argMap.put("owner", new String[] { "Fry" });
+        String jsonResult = todoController.getTodos(argMap);
+        BsonArray docs = parseJsonArray(jsonResult);
+
+        assertEquals("Should be 1 todo", 1, docs.size());
+        assertEquals("Owner should match", "Fry", docs.get(0).asDocument().get("owner").asString().getValue());
+        assertEquals("Category should match", "homework", docs.get(0).asDocument().get("category").asString().getValue());
+    }
     public void getTodobyId() {
         String jsonResult = todoController.getTodo(exampleTodoID.toHexString());
         Document exampleTodoDoc = Document.parse(jsonResult);

--- a/server/src/test/java/umm3601/todo/TodoControllerSpec.java
+++ b/server/src/test/java/umm3601/todo/TodoControllerSpec.java
@@ -128,6 +128,17 @@ public class TodoControllerSpec {
         assertEquals("Owners should match", expectedOwners, owners);
     }
 
+    @Test
+    public void getTodosWithStatus() {
+        Map<String, String[]> argMap = new HashMap<>();
+        argMap.put("status", new String[] { "complete" });
+        String jsonResult = todoController.getTodos(argMap);
+        BsonArray docs = parseJsonArray(jsonResult);
+
+        assertEquals("Should be 1 todo", 1, docs.size());
+        assertEquals("Status should match", true, docs.get(0).asDocument().get("status").asBoolean().getValue());
+    }
+
     public void getTodobyId() {
         String jsonResult = todoController.getTodo(exampleTodoID.toHexString());
         Document exampleTodoDoc = Document.parse(jsonResult);


### PR DESCRIPTION
Adds filtering to the API. It can filter by:
- Owner (2dd34de)
- Status (complete or incomplete) (bd23de2)
- Category (6e12726)
- Text contained in the body (it searches within the body and doesn't just match the whole thing) (a8efeab)

