### PR TITLE
Add limiting API

### DIFF
--- a/server/src/main/java/umm3601/todo/TodoController.java
+++ b/server/src/main/java/umm3601/todo/TodoController.java
@@ -127,6 +127,10 @@ public class TodoController {
         //FindIterable comes from mongo, Document comes from Gson
         FindIterable<Document> matchingTodos = todoCollection.find(filterDoc);
 
+        if(queryParams.containsKey("limit")) {
+            matchingTodos.limit(Integer.parseInt(queryParams.get("limit")[0]));
+        }
+
         return JSON.serialize(matchingTodos);
     }
 

--- a/server/src/test/java/umm3601/todo/TodoControllerSpec.java
+++ b/server/src/test/java/umm3601/todo/TodoControllerSpec.java
@@ -180,6 +180,18 @@ public class TodoControllerSpec {
         assertEquals("Owner should match", "Fry", docs.get(0).asDocument().get("owner").asString().getValue());
         assertEquals("Category should match", "homework", docs.get(0).asDocument().get("category").asString().getValue());
     }
+
+    @Test
+    public void getTodosLimited() {
+        Map<String, String[]> argMap = new HashMap<>();
+        argMap.put("limit", new String[]{"2"});
+        String jsonResult = todoController.getTodos(argMap);
+        BsonArray docs = parseJsonArray(jsonResult);
+
+
+        assertEquals("Should be 2 todos", 2, docs.size());
+    }
+
     public void getTodobyId() {
         String jsonResult = todoController.getTodo(exampleTodoID.toHexString());
         Document exampleTodoDoc = Document.parse(jsonResult);


### PR DESCRIPTION
Adds a limit option to the API that limits the number of todos returned. Also adds testing for this. Closes #6