### PR TITLE
Add new todos

### DIFF
--- a/server/src/main/java/umm3601/Server.java
+++ b/server/src/main/java/umm3601/Server.java
@@ -67,6 +67,7 @@ public class Server {
 
         get("api/todos", todoController::getTodos);
         get("api/todos/:id", todoController::getTodo);
+        post("api/todos/new", todoController::addNewTodo);
 
         // An example of throwing an unhandled exception so you can see how the
         // Java Spark debugger displays errors like this.

--- a/server/src/main/java/umm3601/todo/TodoController.java
+++ b/server/src/main/java/umm3601/todo/TodoController.java
@@ -1,6 +1,7 @@
 package umm3601.todo;
 
 import com.google.gson.Gson;
+import com.mongodb.BasicDBObject;
 import com.mongodb.MongoException;
 import com.mongodb.client.FindIterable;
 import com.mongodb.client.MongoCollection;
@@ -138,6 +139,53 @@ public class TodoController {
         }
 
         return JSON.serialize(matchingTodos);
+    }
+
+    /**
+     *
+     * @param req
+     * @param res
+     * @return
+     */
+    public boolean addNewTodo(Request req, Response res)
+    {
+
+        res.type("application/json");
+        Object o = JSON.parse(req.body());
+        try {
+            if(o.getClass().equals(BasicDBObject.class))
+            {
+                try {
+                    BasicDBObject dbO = (BasicDBObject) o;
+
+                    String owner = dbO.getString("owner");
+                    //For some reason age is a string right now, caused by angular.
+                    //This is a problem and should not be this way but here ya go
+                    boolean status = dbO.getBoolean("status");
+                    String body = dbO.getString("body");
+                    String category = dbO.getString("category");
+
+                    System.err.println("Adding new todo [owner=" + owner + ", status=" + status + " body=" + body + " category=" + category + ']');
+                    return addNewTodo(owner, status, body, category);
+                }
+                catch(NullPointerException e)
+                {
+                    System.err.println("A value was malformed or omitted, new user request failed.");
+                    return false;
+                }
+
+            }
+            else
+            {
+                System.err.println("Expected BasicDBObject, received " + o.getClass());
+                return false;
+            }
+        }
+        catch(RuntimeException ree)
+        {
+            ree.printStackTrace();
+            return false;
+        }
     }
 
     public boolean addNewTodo(String owner, boolean status, String body, String category) {

--- a/server/src/main/java/umm3601/todo/TodoController.java
+++ b/server/src/main/java/umm3601/todo/TodoController.java
@@ -1,6 +1,7 @@
 package umm3601.todo;
 
 import com.google.gson.Gson;
+import com.mongodb.MongoException;
 import com.mongodb.client.FindIterable;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
@@ -137,6 +138,26 @@ public class TodoController {
         }
 
         return JSON.serialize(matchingTodos);
+    }
+
+    public boolean addNewTodo(String owner, boolean status, String body, String category) {
+
+        Document newTodo = new Document();
+        newTodo.append("owner", owner);
+        newTodo.append("status", status);
+        newTodo.append("body", body);
+        newTodo.append("category", category);
+
+        try {
+            todoCollection.insertOne(newTodo);
+        }
+        catch(MongoException me)
+        {
+            me.printStackTrace();
+            return false;
+        }
+
+        return true;
     }
 
 }

--- a/server/src/test/java/umm3601/todo/TodoControllerSpec.java
+++ b/server/src/test/java/umm3601/todo/TodoControllerSpec.java
@@ -232,4 +232,50 @@ public class TodoControllerSpec {
         assertEquals("Category should match", "homework", exampleTodoDoc.get("category"));
     }
 
+    @Test
+    public void addNewTodo() {
+        todoController.addNewTodo("testOwner", true, "test body", "testCategory");
+
+        Map<String, String[]> emptyMap = new HashMap<>();
+        String jsonResult = todoController.getTodos(emptyMap);
+        BsonArray docs = parseJsonArray(jsonResult);
+
+        assertEquals("Should be 5 todos", 5, docs.size());
+        List<String> owners = docs
+            .stream()
+            .map(TodoControllerSpec::getOwner)
+            .sorted()
+            .collect(Collectors.toList());
+        List<String> expectedOwners = Arrays.asList("Barry", "Blanche", "Fry", "Fry", "testOwner");
+        assertEquals("Owners should match", expectedOwners, owners);
+
+        List<String> categories = docs
+            .stream()
+            .map(TodoControllerSpec::getCategory)
+            .sorted()
+            .collect(Collectors.toList());
+        List<String> expectedCategories = Arrays.asList("homework", "homework", "software design", "testCategory", "video games");
+        assertEquals("Categories should match", expectedCategories, categories);
+    }
+
+    @Test
+    public void addMultipleNewTodo() {
+        todoController.addNewTodo("testOwner", true, "test body", "testCategory");
+
+        Map<String, String[]> emptyMap = new HashMap<>();
+        BsonArray docs = parseJsonArray(todoController.getTodos(emptyMap));
+
+        assertEquals("Should be 5 todos", 5, docs.size());
+
+        todoController.addNewTodo("testOwner", true, "test body", "testCategory");
+        docs = parseJsonArray(todoController.getTodos(emptyMap));
+
+        assertEquals("Should be 6 todos", 6, docs.size());
+
+        todoController.addNewTodo("testOwner", true, "test body", "testCategory");
+        docs = parseJsonArray(todoController.getTodos(emptyMap));
+
+        assertEquals("Should be 7 todos", 7, docs.size());
+    }
+
 }


### PR DESCRIPTION
This adds the ability to add new todos to the database and also adds testing for this functionality. It adds the `/api/todos/new` endpoint where a post request can be sent to create a new todo.