### PR TITLE
Adds a todo summary to the API

### DIFF
--- a/server/src/main/java/umm3601/Server.java
+++ b/server/src/main/java/umm3601/Server.java
@@ -68,6 +68,7 @@ public class Server {
         get("api/todos", todoController::getTodos);
         get("api/todos/:id", todoController::getTodo);
         post("api/todos/new", todoController::addNewTodo);
+        get("api/todoSummary", todoController :: todoSummary);
 
         // An example of throwing an unhandled exception so you can see how the
         // Java Spark debugger displays errors like this.


### PR DESCRIPTION
This adds a `api/todosummary` endpoint which provides a summary of the percents of todos completed in total and by category and owner. Closes #16

Example output:
```json
{
    "percentToDosComplete": 0.4766666666666667,
    "categoriesPercentComplete": {
        "software design": 0.4864864864864865,
        "homework": 0.4936708860759494,
        "groceries": 0.5,
        "video games": 0.4225352112676056
    },
    "ownersPercentComplete": {
        "Roberta": 0.5652173913043478,
        "Dawn": 0.46,
        "Barry": 0.5294117647058824,
        "Blanche": 0.5116279069767442,
        "Workman": 0.3673469387755102,
        "Fry": 0.4426229508196721
    }
}
```